### PR TITLE
Sdk2.7.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ use log::{Metadata, Record, SetLoggerError};
 extern crate std;
 
 #[cfg(feature = "embedded-logging")]
+use log::Level;
+
+#[cfg(feature = "embedded-logging")]
 mod write_to;
 
 #[cfg(feature = "embedded-logging")]
@@ -13,64 +16,6 @@ mod write_to;
 extern "C" {
     // u8 is a lie but same binary definition
     pub fn embedded_logging_log(level: u8, message: *const u8);
-}
-
-#[repr(u8)]
-pub enum EmbeddedLogLevel {
-    Error = 1,
-    Warn = 2,
-    Info = 3,
-    Debug = 4,
-    Trace = 5,
-}
-
-impl From<log::Level> for EmbeddedLogLevel {
-    fn from(level: log::Level) -> Self {
-        match level {
-            log::Level::Error => EmbeddedLogLevel::Error,
-            log::Level::Warn => EmbeddedLogLevel::Warn,
-            log::Level::Info => EmbeddedLogLevel::Info,
-            log::Level::Debug => EmbeddedLogLevel::Debug,
-            log::Level::Trace => EmbeddedLogLevel::Trace,
-        }
-    }
-}
-
-impl From<EmbeddedLogLevel> for log::LevelFilter {
-    fn from(level: EmbeddedLogLevel) -> Self {
-        match level {
-            EmbeddedLogLevel::Error => log::LevelFilter::Error,
-            EmbeddedLogLevel::Warn => log::LevelFilter::Warn,
-            EmbeddedLogLevel::Info => log::LevelFilter::Info,
-            EmbeddedLogLevel::Debug => log::LevelFilter::Debug,
-            EmbeddedLogLevel::Trace => log::LevelFilter::Trace,
-        }
-    }
-}
-
-impl From<EmbeddedLogLevel> for u8 {
-    fn from(level: EmbeddedLogLevel) -> Self {
-        match level {
-            EmbeddedLogLevel::Error => 1,
-            EmbeddedLogLevel::Warn => 2,
-            EmbeddedLogLevel::Info => 3,
-            EmbeddedLogLevel::Debug => 4,
-            EmbeddedLogLevel::Trace => 5,
-        }
-    }
-}
-
-impl From<u8> for EmbeddedLogLevel {
-    fn from(level: u8) -> Self {
-        match level {
-            1 => EmbeddedLogLevel::Error,
-            2 => EmbeddedLogLevel::Warn,
-            3 => EmbeddedLogLevel::Info,
-            4 => EmbeddedLogLevel::Debug,
-            5 => EmbeddedLogLevel::Trace,
-            _ => panic!("Unsupported log level"),
-        }
-    }
 }
 
 struct EmbeddedLogger;
@@ -88,11 +33,17 @@ impl log::Log for EmbeddedLogger {
 
         #[cfg(feature = "embedded-logging")]
         {
-            let level = EmbeddedLogLevel::from(record.level());
+            let level = match record.level() {
+                Level::Error => 1,
+                Level::Warn => 2,
+                Level::Info => 3,
+                Level::Debug => 4,
+                Level::Trace => 4,
+            };
 
             let mut buffer = [0u8; 256];
             if let Ok(out) = write_to::show(&mut buffer, format_args!("{}", record.args())) {
-                unsafe { embedded_logging_log(level.into(), out.as_ptr()) }
+                unsafe { embedded_logging_log(level, out.as_ptr()) }
             }
         }
 
@@ -107,7 +58,7 @@ impl log::Log for EmbeddedLogger {
 
 static LOGGER: EmbeddedLogger = EmbeddedLogger;
 
-pub fn init_logger(max_log_level: EmbeddedLogLevel) -> Result<(), SetLoggerError> {
-    log::set_max_level(max_log_level.into());
+pub fn init_logger() -> Result<(), SetLoggerError> {
+    log::set_max_level(log::LevelFilter::Debug);
     log::set_logger(&LOGGER)
 }

--- a/zephyr/wiring.c
+++ b/zephyr/wiring.c
@@ -5,7 +5,7 @@ static void invoke_logger(uint8_t level, ...)
   va_list ap;
   va_start(ap, level);
 
-  log2_generic(level, "%s", ap);
+  log_generic(level, "%s", ap);
 
   va_end(ap);
 }


### PR DESCRIPTION
* Changes name of log function to match zephyr removing references to logging version 2
* Removes setting of log level at runtime in favour of compile time setting provided in drivers