### PR TITLE
fix: dont call log generic when minimal logging is set

### DIFF
--- a/zephyr/wiring.c
+++ b/zephyr/wiring.c
@@ -5,7 +5,9 @@ static void invoke_logger(uint8_t level, ...)
   va_list ap;
   va_start(ap, level);
 
+#if !CONFIG_LOG_MODE_MINIMAL
   log_generic(level, "%s", ap);
+#endif
 
   va_end(ap);
 }


### PR DESCRIPTION
this handles the case in tests where logging isnt fully available